### PR TITLE
Allow emails to fallback to claimers and listing author

### DIFF
--- a/includes/forms/cf7.php
+++ b/includes/forms/cf7.php
@@ -77,33 +77,11 @@ class Astoundify_Job_Manager_Contact_Listing_Form_CF7 extends Astoundify_Job_Man
 
 		$recipient = $object->_application ? $object->_application : $object->_candidate_email;
 
-		//if we couldn't find the email by now, get it from the listing owner
+		//if we couldn't find the email by now, get it from the listing owner/author
 		if ( empty( $recipient ) ) {
-			$owner_ID = false;
 
-			//first look at the metas
-			$meta = get_post_meta( $post_id );
-
-			/**
-			 * first check if this listing has been claimed by anybody
-			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
-			 */
-			$found_owner = false;
-			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
-				//get the first valid user ID that claimed the listing
-				foreach ( $meta['_claimed'] as $ID ) {
-					if ( ! empty( $ID ) ) {
-						$owner_ID = $ID;
-						$found_owner = true;
-						break;
-					}
-				}
-			}
-
-			if ( ! $found_owner ) {
-				//just get the email of the listing author if nothing else works
-				$owner_ID = $object->post_author;
-			}
+			//just get the email of the listing author
+			$owner_ID = $object->post_author;
 
 			//retrieve the owner user data to get the email
 			$owner_info = get_userdata( $owner_ID );
@@ -111,7 +89,6 @@ class Astoundify_Job_Manager_Contact_Listing_Form_CF7 extends Astoundify_Job_Man
 			if ( false !== $owner_info ) {
 				$recipient = $owner_info->user_email;
 			}
-
 		}
 
 		$components[ 'recipient' ] = $recipient;

--- a/includes/forms/cf7.php
+++ b/includes/forms/cf7.php
@@ -77,6 +77,43 @@ class Astoundify_Job_Manager_Contact_Listing_Form_CF7 extends Astoundify_Job_Man
 
 		$recipient = $object->_application ? $object->_application : $object->_candidate_email;
 
+		//if we couldn't find the email by now, get it from the listing owner
+		if ( empty( $recipient ) ) {
+			$owner_ID = false;
+
+			//first look at the metas
+			$meta = get_post_meta( $post_id );
+
+			/**
+			 * first check if this listing has been claimed by anybody
+			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
+			 */
+			$found_owner = false;
+			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
+				//get the first valid user ID that claimed the listing
+				foreach ( $meta['_claimed'] as $ID ) {
+					if ( ! empty( $ID ) ) {
+						$owner_ID = $ID;
+						$found_owner = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $found_owner ) {
+				//just get the email of the listing author if nothing else works
+				$owner_ID = $object->post_author;
+			}
+
+			//retrieve the owner user data to get the email
+			$owner_info = get_userdata( $owner_ID );
+
+			if ( false !== $owner_info ) {
+				$recipient = $owner_info->user_email;
+			}
+
+		}
+
 		$components[ 'recipient' ] = $recipient;
 
 		return $components;

--- a/includes/forms/gravityforms.php
+++ b/includes/forms/gravityforms.php
@@ -74,33 +74,11 @@ class Astoundify_Job_Manager_Contact_Listing_Form_GravityForms extends Astoundif
 
 		$to = $object->_application ? $object->_application : $object->_candidate_email;
 
-		//if we couldn't find the email by now, get it from the listing owner
+		//if we couldn't find the email by now, get it from the listing owner/author
 		if ( empty( $to ) ) {
-			$owner_ID = false;
 
-			//first look at the metas
-			$meta = get_post_meta( $listing_ID );
-
-			/**
-			 * first check if this listing has been claimed by anybody
-			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
-			 */
-			$found_owner = false;
-			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
-				//get the first valid user ID that claimed the listing
-				foreach ( $meta['_claimed'] as $ID ) {
-					if ( ! empty( $ID ) ) {
-						$owner_ID = $ID;
-						$found_owner = true;
-						break;
-					}
-				}
-			}
-
-			if ( ! $found_owner ) {
-				//just get the email of the listing author if nothing else works
-				$owner_ID = $object->post_author;
-			}
+			//just get the email of the listing author
+			$owner_ID = $object->post_author;
 
 			//retrieve the owner user data to get the email
 			$owner_info = get_userdata( $owner_ID );
@@ -108,7 +86,6 @@ class Astoundify_Job_Manager_Contact_Listing_Form_GravityForms extends Astoundif
 			if ( false !== $owner_info ) {
 				$to = $owner_info->user_email;
 			}
-
 		}
 
 		$notification[ 'to' ] = $to;

--- a/includes/forms/gravityforms.php
+++ b/includes/forms/gravityforms.php
@@ -51,16 +51,18 @@ class Astoundify_Job_Manager_Contact_Listing_Form_GravityForms extends Astoundif
 
 		$notification[ 'toType' ] = 'email';
 
-		$listing = false;
+		$listing_ID = false;
 		$fields  = $form[ 'fields' ];
 
 		foreach ( $fields as $check ) {
-			if ( $check[ 'inputName' ] == 'Listing ID' ) {
-				$listing = $check[ 'id' ];
+			if ( $check[ 'label' ] == 'Listing ID' ) {
+				if ( isset( $entry[ $check[ 'id' ] ] ) ) {
+					$listing_ID = $entry[ $check['id'] ];
+				}
 			}
 		}
 
-		$object = get_post( $listing );
+		$object = get_post( $listing_ID );
 
 		if ( ! isset( $this->forms[ $object->post_type ] ) ) {
 			return;
@@ -71,6 +73,43 @@ class Astoundify_Job_Manager_Contact_Listing_Form_GravityForms extends Astoundif
 		}
 
 		$to = $object->_application ? $object->_application : $object->_candidate_email;
+
+		//if we couldn't find the email by now, get it from the listing owner
+		if ( empty( $to ) ) {
+			$owner_ID = false;
+
+			//first look at the metas
+			$meta = get_post_meta( $listing_ID );
+
+			/**
+			 * first check if this listing has been claimed by anybody
+			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
+			 */
+			$found_owner = false;
+			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
+				//get the first valid user ID that claimed the listing
+				foreach ( $meta['_claimed'] as $ID ) {
+					if ( ! empty( $ID ) ) {
+						$owner_ID = $ID;
+						$found_owner = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $found_owner ) {
+				//just get the email of the listing author if nothing else works
+				$owner_ID = $object->post_author;
+			}
+
+			//retrieve the owner user data to get the email
+			$owner_info = get_userdata( $owner_ID );
+
+			if ( false !== $owner_info ) {
+				$to = $owner_info->user_email;
+			}
+
+		}
 
 		$notification[ 'to' ] = $to;
 

--- a/includes/forms/ninjaforms.php
+++ b/includes/forms/ninjaforms.php
@@ -77,7 +77,9 @@ class Astoundify_Job_Manager_Contact_Listing_Form_NinjaForms extends Astoundify_
 			}
 		}
 
-		$object = get_post( $ninja_forms_processing->get_field_value( $field_id ) );
+		$listing_ID = $ninja_forms_processing->get_field_value( $field_id );
+
+		$object = get_post( $listing_ID );
 
 		if ( ! is_a( $object, 'WP_Post' ) ) {
 			return $setting;
@@ -88,6 +90,43 @@ class Astoundify_Job_Manager_Contact_Listing_Form_NinjaForms extends Astoundify_
 		}
 
 		$setting[ $fake ] = $object->_application ? $object->_application : $object->_candidate_email;
+
+		//if we couldn't find the email by now, get it from the listing owner
+		if ( empty( $setting[ $fake ] ) ) {
+			$owner_ID = false;
+
+			//first look at the metas
+			$meta = get_post_meta( $listing_ID );
+
+			/**
+			 * first check if this listing has been claimed by anybody
+			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
+			 */
+			$found_owner = false;
+			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
+				//get the first valid user ID that claimed the listing
+				foreach ( $meta['_claimed'] as $ID ) {
+					if ( ! empty( $ID ) ) {
+						$owner_ID = $ID;
+						$found_owner = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $found_owner ) {
+				//just get the email of the listing author if nothing else works
+				$owner_ID = $object->post_author;
+			}
+
+			//retrieve the owner user data to get the email
+			$owner_info = get_userdata( $owner_ID );
+
+			if ( false !== $owner_info ) {
+				$setting[ $fake ] = $owner_info->user_email;
+			}
+
+		}
 
 		return $setting;
 	}

--- a/includes/forms/ninjaforms.php
+++ b/includes/forms/ninjaforms.php
@@ -91,33 +91,11 @@ class Astoundify_Job_Manager_Contact_Listing_Form_NinjaForms extends Astoundify_
 
 		$setting[ $fake ] = $object->_application ? $object->_application : $object->_candidate_email;
 
-		//if we couldn't find the email by now, get it from the listing owner
+		//if we couldn't find the email by now, get it from the listing owner/author
 		if ( empty( $setting[ $fake ] ) ) {
-			$owner_ID = false;
 
-			//first look at the metas
-			$meta = get_post_meta( $listing_ID );
-
-			/**
-			 * first check if this listing has been claimed by anybody
-			 * @link https://astoundify.com/downloads/wp-job-manager-claim-listing/
-			 */
-			$found_owner = false;
-			if ( isset( $meta['_claimed'] ) && ! empty( $meta['_claimed'] ) ) {
-				//get the first valid user ID that claimed the listing
-				foreach ( $meta['_claimed'] as $ID ) {
-					if ( ! empty( $ID ) ) {
-						$owner_ID = $ID;
-						$found_owner = true;
-						break;
-					}
-				}
-			}
-
-			if ( ! $found_owner ) {
-				//just get the email of the listing author if nothing else works
-				$owner_ID = $object->post_author;
-			}
+			//just get the email of the listing author
+			$owner_ID = $object->post_author;
 
 			//retrieve the owner user data to get the email
 			$owner_info = get_userdata( $owner_ID );
@@ -125,7 +103,6 @@ class Astoundify_Job_Manager_Contact_Listing_Form_NinjaForms extends Astoundify_
 			if ( false !== $owner_info ) {
 				$setting[ $fake ] = $owner_info->user_email;
 			}
-
 		}
 
 		return $setting;

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ The plugin can also be used on any theme but no extra styling (outside the CSS t
 You **must** create a *hidden* field with the following specific settings:
 
 * **Label:** Listing ID
-* **Allow field to be dynamically populated:** `{entry_id}`
+* **Allow field to be dynamically populated:** `{embed_post:ID}`
 
 The Job/Resume listing must also have an email address associated with it, not a URL to a website.
 


### PR DESCRIPTION
If for a listing a application or candidate email could not be found (very common for sites/themes that use WP Job Manager for listings rather than jobs), the listing's claimed owner (if the Claimed Listings plugin is used) should be used.

If nothing else works, just use the listing's author email. It's better than to show errors to users or worst (like Gravity Forms does) silently fail with big success message.