### PR TITLE
Fix pll_get_post function check

### DIFF
--- a/includes/forms/cf7.php
+++ b/includes/forms/cf7.php
@@ -41,7 +41,7 @@ class Astoundify_Job_Manager_Contact_Listing_Form_CF7 extends Astoundify_Job_Man
 	public function output_form($form) {
 		$args = apply_filters( 'job_manager_contact_listing_cf7_apply_form_args', '' );
 
-		if ( function_exists( 'pll_get_posts' ) ) {
+		if ( function_exists( 'pll_get_post' ) ) {
 			$form = pll_get_post( $form );
 		}
 


### PR DESCRIPTION
Fix name of function being checked to exist (`pll_get_post` instead of `pll_get_posts`).